### PR TITLE
Geometry QoL Changes

### DIFF
--- a/SymplePlanner/src/main/java/top/symple/sympleplanner/geometry/Pose2d.kt
+++ b/SymplePlanner/src/main/java/top/symple/sympleplanner/geometry/Pose2d.kt
@@ -2,14 +2,14 @@ package top.symple.sympleplanner.geometry
 
 data class Pose2d(val position: Translation2d, val heading: Rotation2d) {
     companion object {
-        fun zero() = Pose2d(Translation2d.zero(), Rotation2d.zero())
+        @JvmStatic fun zero() = Pose2d(Translation2d.zero(), Rotation2d.zero())
 
-        fun from(position: Translation2d, rotation2d: Rotation2d) = Pose2d(position, rotation2d)
-        fun from(x: Double, y: Double, rotation2d: Rotation2d) = Pose2d(Translation2d(x, y), rotation2d)
-        fun fromRadians(position: Translation2d, radians: Double) = Pose2d(position, Rotation2d.fromRadians(radians))
-        fun fromRadians(x: Double, y: Double, radians: Double) = Pose2d(Translation2d(x, y), Rotation2d.fromRadians(radians))
-        fun fromDegrees(position: Translation2d, degrees: Double) = Pose2d(position, Rotation2d.fromDegrees(degrees))
-        fun fromDegrees(x: Double, y: Double, degrees: Double) = Pose2d(Translation2d(x, y), Rotation2d.fromDegrees(degrees))
+        @JvmStatic fun from(position: Translation2d, rotation2d: Rotation2d) = Pose2d(position, rotation2d)
+        @JvmStatic fun from(x: Double, y: Double, rotation2d: Rotation2d) = Pose2d(Translation2d(x, y), rotation2d)
+        @JvmStatic fun fromRadians(position: Translation2d, radians: Double) = Pose2d(position, Rotation2d.fromRadians(radians))
+        @JvmStatic fun fromRadians(x: Double, y: Double, radians: Double) = Pose2d(Translation2d(x, y), Rotation2d.fromRadians(radians))
+        @JvmStatic fun fromDegrees(position: Translation2d, degrees: Double) = Pose2d(position, Rotation2d.fromDegrees(degrees))
+        @JvmStatic fun fromDegrees(x: Double, y: Double, degrees: Double) = Pose2d(Translation2d(x, y), Rotation2d.fromDegrees(degrees))
     }
 
     operator fun plus(pose2d: Pose2d) = this.transformBy(pose2d)

--- a/SymplePlanner/src/main/java/top/symple/sympleplanner/geometry/Rotation2d.kt
+++ b/SymplePlanner/src/main/java/top/symple/sympleplanner/geometry/Rotation2d.kt
@@ -8,9 +8,9 @@ import kotlin.math.sin
 
 data class Rotation2d(val cosVal: Double, val sinVal: Double) {
     companion object {
-        fun zero() = Rotation2d(1.0, 0.0)
-        fun fromRadians(radians: Double) = Rotation2d(cos(radians), sin(radians))
-        fun fromDegrees(degrees: Double) = Rotation2d(cos(Math.toRadians(degrees)), sin(Math.toRadians(degrees)))
+        @JvmStatic fun zero() = Rotation2d(1.0, 0.0)
+        @JvmStatic fun fromRadians(radians: Double) = Rotation2d(cos(radians), sin(radians))
+        @JvmStatic fun fromDegrees(degrees: Double) = Rotation2d(cos(Math.toRadians(degrees)), sin(Math.toRadians(degrees)))
     }
 
     operator fun plus(rotation2d: Rotation2d) = this * rotation2d

--- a/SymplePlanner/src/main/java/top/symple/sympleplanner/geometry/Translation2d.kt
+++ b/SymplePlanner/src/main/java/top/symple/sympleplanner/geometry/Translation2d.kt
@@ -22,6 +22,7 @@ data class Translation2d(val x: Double, val y: Double) {
 
     operator fun times(num: Double) = Translation2d(x * num, y * num)
     operator fun times(translation2d: Translation2d) = Translation2d(x * translation2d.x, y * translation2d.y)
+    operator fun times(rotation2d: Rotation2d) = (rotation2d * this).asTranslation2d()
     operator fun div(num: Double) = Translation2d(x / num, y / num)
     operator fun div(translation2d: Translation2d) = Translation2d(x / translation2d.x, y / translation2d.y)
 

--- a/SymplePlanner/src/main/java/top/symple/sympleplanner/geometry/Translation2d.kt
+++ b/SymplePlanner/src/main/java/top/symple/sympleplanner/geometry/Translation2d.kt
@@ -7,11 +7,11 @@ import kotlin.math.sin
 
 data class Translation2d(val x: Double, val y: Double) {
     companion object {
-        fun zero() = Translation2d(0.0, 0.0)
+        @JvmStatic fun zero() = Translation2d(0.0, 0.0)
 
-        fun from(x: Double, y: Double) = Translation2d(x, y)
-        fun fromPolar(radius: Double, theta: Double) = Translation2d(radius * cos(theta), radius * sin(theta))
-        fun fromPolar(radius: Double, rotation2d: Rotation2d) = Translation2d(radius * rotation2d.cosVal, radius * rotation2d.sinVal)
+        @JvmStatic fun from(x: Double, y: Double) = Translation2d(x, y)
+        @JvmStatic fun fromPolar(radius: Double, theta: Double) = Translation2d(radius * cos(theta), radius * sin(theta))
+        @JvmStatic fun fromPolar(radius: Double, rotation2d: Rotation2d) = Translation2d(radius * rotation2d.cosVal, radius * rotation2d.sinVal)
     }
 
     operator fun plus(translation2d: Translation2d) = Translation2d(x + translation2d.x, y + translation2d.y)


### PR DESCRIPTION
 - Add times method to Translation2d that takes Rotation2d as parameter
 - Add JvmStatic decorator to all companion object methods in the geometry classes

The `@JvmStatic` annotation allows static members inside a `companion object` in Kotlin to be accessed without referencing the `Companion` object from Java.

![image](https://github.com/user-attachments/assets/528355af-cade-4988-b37d-22395caf261c)
